### PR TITLE
feat: adding a install-only recipe

### DIFF
--- a/.kitchen_docker.yml
+++ b/.kitchen_docker.yml
@@ -27,3 +27,11 @@ suites:
         server:
           version: '5.1.1'
           edition: 'community'
+  - name: install_only
+    run_list:
+      - recipe[couchbase::install_only]
+    attributes:
+      couchbase:
+        server:
+          version: '5.1.1'
+          edition: 'community'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "jdunn@chef.io"
 license          "MIT"
 description      "Installs and configures Couchbase Server."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "1.5.0"
+version          "1.6.0"
 issues_url       "https://github.com/disney/couchbase/issues"
 source_url       "https://github.com/disney/couchbase"
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -25,9 +25,10 @@
 #
 
 # install missing packages
-%w{wget gnupg2}.each do |x|
+%w{wget gnupg2 python-httplib2}.each do |x|
   package x do
     action :install
+    options "--force-yes"
   end
 end
 
@@ -46,12 +47,4 @@ end
 execute "apt-get update" do
   command "apt-get update"
   action :run
-end
-
-%w{python-httplib2}.each do |x|
-  package x do
-    action :install
-    options "--force-yes"
-    not_if "dpkg -l #{x}"
-  end
 end

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -25,7 +25,7 @@
 #
 
 # install missing packages
-%w{wget gnupg2 python-httplib2}.each do |x|
+%w{wget gnupg2 python-httplib2 libssl1.0.0}.each do |x|
   package x do
     action :install
     options "--force-yes"

--- a/recipes/install_only.rb
+++ b/recipes/install_only.rb
@@ -1,0 +1,14 @@
+include_recipe "couchbase::dependencies"
+
+remote_file File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
+  source node['couchbase']['server']['package_full_url']
+  action :create_if_missing
+end
+
+dpkg_package File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
+  action :install
+end
+
+service node['couchbase']['server']['service_name'] do
+  action [:stop, :disable]
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -49,12 +49,8 @@ remote_file File.join(Chef::Config[:file_cache_path], node['couchbase']['server'
   action :create_if_missing
 end
 
-case node['platform_family']
-  when "debian"
-    package "libssl1.0.0"
-    dpkg_package File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
-      notifies :run, "ruby_block[block_until_operational]", :immediately
-    end
+dpkg_package File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
+  notifies :run, "ruby_block[block_until_operational]", :immediately
 end
 
 ruby_block "block_until_operational" do


### PR DESCRIPTION
the idea is to use that to install CB on backup nodes, which does not require couchbase to be running...